### PR TITLE
adds support for comment elements in user agent

### DIFF
--- a/Fusillade/RateLimitedHttpMessageHandler.cs
+++ b/Fusillade/RateLimitedHttpMessageHandler.cs
@@ -121,7 +121,7 @@ namespace Fusillade
                 request.Headers.Accept.ConcatenateAll(x => x.CharSet + x.MediaType),
                 request.Headers.AcceptEncoding.ConcatenateAll(x => x.Value),
                 (request.Headers.Referrer ?? new Uri("http://example")).AbsoluteUri,
-                request.Headers.UserAgent.ConcatenateAll(x => x.Product.ToString()),
+                request.Headers.UserAgent.ConcatenateAll(x => (x.Product != null ? x.Product.ToString() : x.Comment)),
             }.Aggregate(new StringBuilder(), (acc, x) => { acc.AppendLine(x); return acc; });
 
             if (request.Headers.Authorization != null) {


### PR DESCRIPTION
When using a user agent with "comments" section e.g. "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1229.94 Safari/537.4" caused null reference exception because the Product property is null.