### PR TITLE
Implement request caching and offline retrieval of said caching

### DIFF
--- a/Fusillade.Tests/Fusillade.Tests.csproj
+++ b/Fusillade.Tests/Fusillade.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.core.2.0.0-beta-build2616\build\portable-net45+wp80+win\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0-beta-build2616\build\portable-net45+wp80+win\xunit.core.props')" />
+  <Import Project="..\packages\xunit.core.2.1.0-beta1-build2945\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.1.0-beta1-build2945\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,7 +13,7 @@
     <AssemblyName>Fusillade.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>cffa8b54</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>953c662b</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -75,14 +76,16 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\packages\xunit.abstractions.2.0.0-beta-build2616\lib\net35\xunit.abstractions.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\packages\xunit.assert.2.0.0-beta-build2616\lib\portable-net45+wp80+win\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.2945, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\xunit.assert.2.1.0-beta1-build2945\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\packages\xunit.core.2.0.0-beta-build2616\lib\portable-net45+wp80+win\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.2945, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0-beta1-build2945\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -110,7 +113,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0-beta-build2616\build\portable-net45+wp80+win\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0-beta-build2616\build\portable-net45+wp80+win\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.1.0-beta1-build2945\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.1.0-beta1-build2945\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Fusillade.Tests/Fusillade.Tests.csproj
+++ b/Fusillade.Tests/Fusillade.Tests.csproj
@@ -89,6 +89,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Http\HttpSchedulerCachingTests.cs" />
     <Compile Include="Http\HttpSchedulerSharedTests.cs" />
     <Compile Include="Http\TestHttpMessageHandler.cs" />
     <Compile Include="IntegrationTestHelper.cs" />

--- a/Fusillade.Tests/Fusillade.Tests.csproj
+++ b/Fusillade.Tests/Fusillade.Tests.csproj
@@ -33,11 +33,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Akavache">
+      <HintPath>..\packages\akavache.core.4.1.1\lib\net45\Akavache.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Reactive.Testing, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Rx-Testing.2.2.4\lib\net45\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Punchclock, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Punchclock.1.1.1\lib\Portable-net45+win+wpa81+wp80\Punchclock.dll</HintPath>
@@ -48,34 +55,38 @@
     <Reference Include="ReactiveUI.Testing">
       <HintPath>..\packages\reactiveui-testing.5.99.5-beta\lib\net45\ReactiveUI.Testing.dll</HintPath>
     </Reference>
-    <Reference Include="Splat, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.3.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.3.1\lib\Net45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.3.3\lib\Net45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Reactive.Core, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Core.2.2.4\lib\net45\System.Reactive.Core.dll</HintPath>
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Interfaces.2.2.4\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Linq.2.2.4\lib\net45\System.Reactive.Linq.dll</HintPath>
+      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.PlatformServices, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-PlatformServices.2.2.4\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Windows.Threading">
+      <HintPath>..\packages\Rx-XAML.2.2.5\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>

--- a/Fusillade.Tests/Http/HttpSchedulerCachingTests.cs
+++ b/Fusillade.Tests/Http/HttpSchedulerCachingTests.cs
@@ -28,7 +28,7 @@ namespace Fusillade.Tests.Http
             });
               
             var contentResponses = new List<byte[]>();
-            var fixture = new RateLimitedHttpMessageHandler(innerHandler, Priority.UserInitiated, cacheResultFunc: async (rq, re, key) => {
+            var fixture = new RateLimitedHttpMessageHandler(innerHandler, Priority.UserInitiated, cacheResultFunc: async (rq, re, key, ct) => {
                 contentResponses.Add(await re.Content.ReadAsByteArrayAsync());
             });
 
@@ -54,8 +54,9 @@ namespace Fusillade.Tests.Http
             });
               
             var etagResponses = new List<string>();
-            var fixture = new RateLimitedHttpMessageHandler(innerHandler, Priority.UserInitiated, cacheResultFunc: async (rq, re, key) => {
+            var fixture = new RateLimitedHttpMessageHandler(innerHandler, Priority.UserInitiated, cacheResultFunc: (rq, re, key, ct) => {
                 etagResponses.Add(re.Headers.ETag.Tag);
+                return Task.FromResult(true);
             });
 
             var client = new HttpClient(fixture);
@@ -68,7 +69,7 @@ namespace Fusillade.Tests.Http
         {
             var cache = new InMemoryBlobCache();
 
-            var cachingHandler = new RateLimitedHttpMessageHandler(new HttpClientHandler(), Priority.UserInitiated, cacheResultFunc: async (rq, resp, key) => {
+            var cachingHandler = new RateLimitedHttpMessageHandler(new HttpClientHandler(), Priority.UserInitiated, cacheResultFunc: async (rq, resp, key, ct) => {
                 var data = await resp.Content.ReadAsByteArrayAsync();
                 await cache.Insert(key, data);
             });

--- a/Fusillade.Tests/Http/HttpSchedulerCachingTests.cs
+++ b/Fusillade.Tests/Http/HttpSchedulerCachingTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fusillade.Tests.Http
+{
+    public class HttpSchedulerCachingTests
+    {
+        [Fact]
+        public async Task CachingFunctionShouldBeCalledWithContent()
+        {
+            var innerHandler = new TestHttpMessageHandler(_ => {
+                var ret = new HttpResponseMessage() {
+                    Content = new StringContent("foo", Encoding.UTF8),
+                    StatusCode = HttpStatusCode.OK,
+                };
+            
+                ret.Headers.ETag = new EntityTagHeaderValue("\"worifjw\"");
+                return Observable.Return(ret);
+            });
+              
+            var contentResponses = new List<byte[]>();
+            var fixture = new RateLimitedHttpMessageHandler(innerHandler, Priority.UserInitiated, cacheResultFunc: async (rq, re, key) => {
+                contentResponses.Add(await re.Content.ReadAsByteArrayAsync());
+            });
+
+            var client = new HttpClient(fixture);
+            var str = await client.GetStringAsync("http://lol/bar");
+
+            Assert.Equal("foo", str);
+            Assert.Equal(1, contentResponses.Count);
+            Assert.Equal(3, contentResponses[0].Length);
+        }
+
+        [Fact]
+        public async Task CachingFunctionShouldPreserveHeaders()
+        {
+            var innerHandler = new TestHttpMessageHandler(_ => {
+                var ret = new HttpResponseMessage() {
+                    Content = new StringContent("foo", Encoding.UTF8),
+                    StatusCode = HttpStatusCode.OK,
+                };
+            
+                ret.Headers.ETag = new EntityTagHeaderValue("\"worifjw\"");
+                return Observable.Return(ret);
+            });
+              
+            var etagResponses = new List<string>();
+            var fixture = new RateLimitedHttpMessageHandler(innerHandler, Priority.UserInitiated, cacheResultFunc: async (rq, re, key) => {
+                etagResponses.Add(re.Headers.ETag.Tag);
+            });
+
+            var client = new HttpClient(fixture);
+            var resp = await client.GetAsync("http://lol/bar");
+            Assert.Equal("\"worifjw\"", etagResponses[0]);
+        }
+    }
+}

--- a/Fusillade.Tests/app.config
+++ b/Fusillade.Tests/app.config
@@ -4,15 +4,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Reactive.Testing" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Fusillade.Tests/packages.config
+++ b/Fusillade.Tests/packages.config
@@ -1,15 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="akavache.core" version="4.1.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="Punchclock" version="1.1.1" targetFramework="net45" />
   <package id="reactiveui-core" version="5.99.5-beta" targetFramework="net45" />
   <package id="reactiveui-testing" version="5.99.5-beta" targetFramework="net45" />
-  <package id="Rx-Core" version="2.2.4" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.4" targetFramework="net45" />
-  <package id="Rx-Linq" version="2.2.4" targetFramework="net45" />
-  <package id="Rx-Main" version="2.2.4" targetFramework="net45" />
-  <package id="Rx-PlatformServices" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Testing" version="2.2.4" targetFramework="net45" />
-  <package id="Splat" version="1.3.1" targetFramework="net45" />
+  <package id="Rx-XAML" version="2.2.5" targetFramework="net45" />
+  <package id="Splat" version="1.3.3" targetFramework="net45" />
   <package id="xunit" version="2.1.0-beta1-build2945" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0-beta1-build2945" targetFramework="net45" />

--- a/Fusillade.Tests/packages.config
+++ b/Fusillade.Tests/packages.config
@@ -10,8 +10,10 @@
   <package id="Rx-PlatformServices" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Testing" version="2.2.4" targetFramework="net45" />
   <package id="Splat" version="1.3.1" targetFramework="net45" />
-  <package id="xunit" version="2.0.0-beta-build2616" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0-beta-build2616" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0-beta-build2616" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0-beta-build2616" targetFramework="net45" />
+  <package id="xunit" version="2.1.0-beta1-build2945" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0-beta1-build2945" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0-beta1-build2945" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0-beta1-build2945" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0-beta1-build1051" targetFramework="net45" />
 </packages>

--- a/Fusillade/Fusillade.csproj
+++ b/Fusillade/Fusillade.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Interfaces.cs" />
+    <Compile Include="OfflineHttpMessageHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RateLimitedHttpMessageHandler.cs" />
   </ItemGroup>

--- a/Fusillade/Interfaces.cs
+++ b/Fusillade/Interfaces.cs
@@ -40,20 +40,14 @@ namespace Fusillade
     {
         static NetCache()
         {
-            var innerHandler = Locator.Current.GetService<HttpMessageHandler>();
+            var innerHandler = Locator.Current.GetService<HttpMessageHandler>() ?? new HttpClientHandler();
 
             // NB: In vNext this value will be adjusted based on the user's
             // network connection, but that requires us to go fully platformy
             // like Splat.
-            if (innerHandler == null) {
-                speculative = new RateLimitedHttpMessageHandler(Priority.Speculative, 0, 1048576 * 5);
-                userInitiated = new RateLimitedHttpMessageHandler(Priority.UserInitiated, 0);
-                background = new RateLimitedHttpMessageHandler(Priority.Background, 0);
-            } else {
-                speculative = new RateLimitedHttpMessageHandler(innerHandler, Priority.Speculative, 0, 1048576 * 5);
-                userInitiated = new RateLimitedHttpMessageHandler(innerHandler, Priority.UserInitiated, 0);
-                background = new RateLimitedHttpMessageHandler(innerHandler, Priority.Background, 0);
-            }
+            speculative = new RateLimitedHttpMessageHandler(innerHandler, Priority.Speculative, 0, 1048576 * 5);
+            userInitiated = new RateLimitedHttpMessageHandler(innerHandler, Priority.UserInitiated, 0);
+            background = new RateLimitedHttpMessageHandler(innerHandler, Priority.Background, 0);
         }
 
         static LimitingHttpMessageHandler speculative;

--- a/Fusillade/Interfaces.cs
+++ b/Fusillade/Interfaces.cs
@@ -38,9 +38,34 @@ namespace Fusillade
         public abstract void ResetLimit(long? maxBytesToRead = null);
     }
 
+    /// <summary>
+    /// This Interface is a simple cache for HTTP requests - it is intentionally
+    /// *not* designed to conform to HTTP caching rules since you most likely want
+    /// to override those rules in a client app anyways.
+    /// </summary>
     public interface IRequestCache
     {
+        /// <summary>
+        /// Implement this method by saving the Body of the response. The 
+        /// response is already downloaded as a ByteArrayContent so you don't
+        /// have to worry about consuming the stream.
+        /// </summary>
+        /// <param name="request">The originating request.</param>
+        /// <param name="response">The response whose body you should save.</param>
+        /// <param name="key">A unique key used to identify the request details.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>Completion.</returns>
         Task Save(HttpRequestMessage request, HttpResponseMessage response, string key, CancellationToken ct);
+
+        /// <summary>
+        /// Implement this by loading the Body of the given request / key.
+        /// </summary>
+        /// <param name="request">The originating request.</param>
+        /// <param name="key">A unique key used to identify the request details, 
+        /// that was given in Save().</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>The Body of the given request, or null if the search 
+        /// completed successfully but the response was not found.</returns>
         Task<byte[]> Fetch(HttpRequestMessage request, string key, CancellationToken ct);
     }
 

--- a/Fusillade/OfflineHttpMessageHandler.cs
+++ b/Fusillade/OfflineHttpMessageHandler.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusillade
+{
+    public class OfflineHttpMessageHandler : HttpMessageHandler
+    {
+        readonly Func<HttpRequestMessage, string, CancellationToken, Task<byte[]>> retrieveBody;
+
+        public OfflineHttpMessageHandler(Func<HttpRequestMessage, string, CancellationToken, Task<byte[]>> retrieveBodyFunc)
+        {
+            retrieveBody = retrieveBodyFunc;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = await this.retrieveBody(request, RateLimitedHttpMessageHandler.UniqueKeyForRequest(request), cancellationToken);
+            if (body == null) {
+                return new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable);
+            }
+
+            var byteContent = new ByteArrayContent(body);
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = byteContent };
+        }
+    }
+}

--- a/Fusillade/OfflineHttpMessageHandler.cs
+++ b/Fusillade/OfflineHttpMessageHandler.cs
@@ -20,6 +20,15 @@ namespace Fusillade
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            var retrieveBody = this.retrieveBody;
+            if (retrieveBody == null && NetCache.RequestCache != null) {
+                retrieveBody = NetCache.RequestCache.Fetch;
+            }
+
+            if (retrieveBody == null) {
+                throw new Exception("Configure NetCache.RequestCache before calling this!");
+            }
+
             var body = await this.retrieveBody(request, RateLimitedHttpMessageHandler.UniqueKeyForRequest(request), cancellationToken);
             if (body == null) {
                 return new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable);

--- a/Fusillade/RateLimitedHttpMessageHandler.cs
+++ b/Fusillade/RateLimitedHttpMessageHandler.cs
@@ -51,19 +51,12 @@ namespace Fusillade
 
         long? maxBytesToRead = null;
 
-        public RateLimitedHttpMessageHandler(Priority basePriority, int priority = 0, long? maxBytesToRead = null, OperationQueue opQueue = null, Func<HttpRequestMessage, HttpResponseMessage, string, Task> cacheResultFunc = null) : base()
+        public RateLimitedHttpMessageHandler(HttpMessageHandler handler, Priority basePriority, int priority = 0, long? maxBytesToRead = null, OperationQueue opQueue = null, Func<HttpRequestMessage, HttpResponseMessage, string, Task> cacheResultFunc = null) : base(handler)
         {
             this.priority = (int)basePriority + priority;
             this.maxBytesToRead = maxBytesToRead;
             this.opQueue = opQueue;
             this.cacheResult = cacheResultFunc;
-        }
-
-        public RateLimitedHttpMessageHandler(HttpMessageHandler handler, Priority basePriority, int priority = 0, long? maxBytesToRead = null, OperationQueue opQueue = null) : base(handler)
-        {
-            this.priority = (int)basePriority + priority;
-            this.maxBytesToRead = maxBytesToRead;
-            this.opQueue = opQueue;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/Fusillade/RateLimitedHttpMessageHandler.cs
+++ b/Fusillade/RateLimitedHttpMessageHandler.cs
@@ -47,11 +47,11 @@ namespace Fusillade
         readonly Dictionary<string, InflightRequest> inflightResponses = 
             new Dictionary<string, InflightRequest>();
 
-        readonly Func<HttpResponseMessage, string, Task> cacheResult;
+        readonly Func<HttpRequestMessage, HttpResponseMessage, string, Task> cacheResult;
 
         long? maxBytesToRead = null;
 
-        public RateLimitedHttpMessageHandler(Priority basePriority, int priority = 0, long? maxBytesToRead = null, OperationQueue opQueue = null, Func<HttpResponseMessage, string, Task> cacheResultFunc = null) : base()
+        public RateLimitedHttpMessageHandler(Priority basePriority, int priority = 0, long? maxBytesToRead = null, OperationQueue opQueue = null, Func<HttpRequestMessage, HttpResponseMessage, string, Task> cacheResultFunc = null) : base()
         {
             this.priority = (int)basePriority + priority;
             this.maxBytesToRead = maxBytesToRead;
@@ -119,7 +119,7 @@ namespace Fusillade
                     newResp.Content = newContent;
 
                     resp = newResp;
-                    await cacheResult(resp, key);
+                    await cacheResult(request, resp, key);
                 }
 
                 lock(inflightResponses) inflightResponses.Remove(key);

--- a/Fusillade/RateLimitedHttpMessageHandler.cs
+++ b/Fusillade/RateLimitedHttpMessageHandler.cs
@@ -71,7 +71,7 @@ namespace Fusillade
                 return tcs.Task;
             }
 
-            var key = uniqueKeyForRequest(request);
+            var key = UniqueKeyForRequest(request);
             var realToken = new CancellationTokenSource();
             var ret = new InflightRequest(() => { 
                 lock (inflightResponses) inflightResponses.Remove(key);
@@ -113,7 +113,7 @@ namespace Fusillade
             this.maxBytesToRead = maxBytesToRead;
         }
 
-        static string uniqueKeyForRequest(HttpRequestMessage request)
+        public static string UniqueKeyForRequest(HttpRequestMessage request)
         {
             var ret = new[] {
                 request.RequestUri.ToString(),


### PR DESCRIPTION
This PR adds a feature to add basic caching and offline support to Fusillade. To use it:

1. Implement `IRequestCache` and assign an instance to `NetCache.RequestCache`
1. Fetch some stuff using the normal `Speculative` / `UserInitiated` HttpClient handlers
1. Later, use the new `NetCache.Offline` handler when you're offline in order to make requests and get responses back that you previously got.

If a request isn't in the Offline handler, you'll get back a 503, which your app can handle

Motivating example:

```cs

[Fact]
public async Task RoundTripIntegrationTest()
{
    var cache = new InMemoryBlobCache();

    var cachingHandler = new RateLimitedHttpMessageHandler(new HttpClientHandler(), Priority.UserInitiated, cacheResultFunc: async (rq, resp, key, ct) => {
        // IRequestCache.Save implementation
        var data = await resp.Content.ReadAsByteArrayAsync();
        await cache.Insert(key, data);
    });

    var client = new HttpClient(cachingHandler);
    var origData = await client.GetStringAsync("http://httpbin.org/get");

    Assert.True(origData.Contains("origin"));
    Assert.Equal(1, (await cache.GetAllKeys()).Count());

    var offlineHandler = new OfflineHttpMessageHandler(async (rq, key, ct) => {
        // IRequestCache.Fetch implementation
        return await cache.Get(key);
    });

    client = new HttpClient(offlineHandler);
    var newData = await client.GetStringAsync("http://httpbin.org/get");

    Assert.Equal(origData, newData);

    bool shouldDie = true;
    try {
        // Not in our original cache!
        await client.GetStringAsync("http://httpbin.org/gzip");
    } catch (Exception ex) {
        shouldDie = false;
        Console.WriteLine(ex);
    }

    Assert.False(shouldDie);
}
```