### PR TITLE
Only de-duplicate relevant requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ as well as [Picasso](http://square.github.io/picasso/).
 Fusillade is a set of HttpMessageHandlers (i.e. "drivers" for HttpClient) that
 make your mobile applications more efficient and responsive:
 
-* **Auto-deduplication of requests** - if every instance of your TweetView
+* **Auto-deduplication of relevant requests** - if every instance of your TweetView
   class requests the same avatar image, Fusillade will only do *one* request
-  and give the result to every instance.
+  and give the result to every instance. All `GET`, `HEAD`, and `OPTIONS` requests are deduplicated.
 
 * **Request Limiting** - Requests are always dispatched 4 at a time (the
   Volley default) - issue lots of requests without overwhelming the network


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes #22 by only de-duplicating `GET`, `HEAD`, and `OPTIONS` requests.

**What is the current behavior? (You can also link to an open issue here)**

To de-duplicate all requests regardless of HTTP method.

**What is the new behavior (if this is a feature change)?**

Only de-duplicate `GET`, `HEAD`, and `OPTIONS`.

**Does this PR introduce a breaking change?**

Only if someone is somehow relying on de-duplication of other HTTP methods. This seems very unlikely to me.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our guidelines: https://github.com/paulcbetts/Fusillade/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

There are some tests that are already in a failing state. This PR makes no attempt to address those.